### PR TITLE
feat: add account activation feature with verification process

### DIFF
--- a/turnomaster/app/Http/Controllers/AuthController.php
+++ b/turnomaster/app/Http/Controllers/AuthController.php
@@ -39,6 +39,7 @@ class AuthController extends Controller
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
+            'activated_account' => false,
         ]);
 
         $code = rand(100000, 999999);
@@ -63,6 +64,10 @@ class AuthController extends Controller
 
         if (! $user) {
             return redirect()->back()->withInput($request->only('email'))->withErrors(['email' => 'No se encontró una cuenta con esta dirección de correo.']);
+        }
+
+        if (! $user->activated_account) {
+            return redirect()->back()->withInput($request->only('email'))->withErrors(['email' => 'La cuenta no ha sido activada. Revisa tu correo para poder activarla.']);
         }
 
         if (! Hash::check($request->password, $user->password)) {

--- a/turnomaster/app/Http/Controllers/VerificationController.php
+++ b/turnomaster/app/Http/Controllers/VerificationController.php
@@ -22,6 +22,7 @@ class VerificationController extends Controller
         }
 
         $user = $verificationCode->user;
+        $user->activated_account = true;
         $user->email_verified_at = Carbon::now();
         $user->save();
 

--- a/turnomaster/app/Models/User.php
+++ b/turnomaster/app/Models/User.php
@@ -25,6 +25,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'activated_account',
     ];
 
     /**

--- a/turnomaster/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/turnomaster/database/migrations/2014_10_12_000000_create_users_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->boolean('activated_account')->default(false);
             $table->rememberToken();
             $table->timestamps();
         });


### PR DESCRIPTION
This pull request introduces a new feature that requires users to activate their accounts via email after registration. The most important changes include adding an `activated_account` field to the `User` model and updating the registration, login, and verification processes to handle account activation.

Changes related to account activation:

* [`turnomaster/app/Http/Controllers/AuthController.php`](diffhunk://#diff-965eabd87c0b6286043864813ac11698d5650a448ea6fea16bcd1da012ac5ba3R42): Added `activated_account` field to the user registration process and included a check during login to ensure the account is activated. [[1]](diffhunk://#diff-965eabd87c0b6286043864813ac11698d5650a448ea6fea16bcd1da012ac5ba3R42) [[2]](diffhunk://#diff-965eabd87c0b6286043864813ac11698d5650a448ea6fea16bcd1da012ac5ba3R69-R72)
* [`turnomaster/app/Http/Controllers/VerificationController.php`](diffhunk://#diff-25a8ce97fc08608ad1274ad89cca12a4f8db01567913f6048a356096106c4743R25): Updated the verification process to set the `activated_account` field to true upon successful verification.
* [`turnomaster/app/Models/User.php`](diffhunk://#diff-b38e4a92097307de71a0a515077e668dc914fd248c3b06de71781bf7518ab16aR28): Added `activated_account` to the list of fillable attributes in the `User` model.
* [`turnomaster/database/migrations/2014_10_12_000000_create_users_table.php`](diffhunk://#diff-d9ed53ea776196cea705edd73f024634e3854e861039fdde33f4e5cbbbaa71d5R20): Added `activated_account` field to the `users` table schema with a default value of false.